### PR TITLE
Enable model switching via API

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,7 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-added-large-files
+
   - repo: 'https://github.com/astral-sh/ruff-pre-commit'
     rev: v0.6.6
     hooks:
@@ -15,6 +16,7 @@ repos:
         args:
           - '--fix'
       - id: ruff-format
+
   - repo: 'https://github.com/pre-commit/mirrors-mypy'
     rev: v1.11.2
     hooks:

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,10 @@
-mode: BACKEND
+mode: CLI
 logging_level: DEBUG
 production_mode: false
 learning_materials: ./learning_assets
 experiment_implementation: ./tests/model
 experiment_results: ./tests/model/results
+port: 8000
+server: 127.0.0.1
+question_generation_model: T5 (fine-tuned)
+natural_language_inference_model: roberta

--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,4 @@
-mode: CLI
+mode: BACKEND
 logging_level: DEBUG
 production_mode: false
 learning_materials: ./learning_assets
@@ -6,5 +6,5 @@ experiment_implementation: ./tests/model
 experiment_results: ./tests/model/results
 port: 8000
 server: 127.0.0.1
-question_generation_model: T5 (fine-tuned)
+question_generation_model: t5
 natural_language_inference_model: roberta

--- a/knowledge_verificator/backend.py
+++ b/knowledge_verificator/backend.py
@@ -8,9 +8,11 @@ from knowledge_verificator.materials import Material, MaterialDatabase
 from knowledge_verificator.io_handler import get_config
 from knowledge_verificator.nli import (
     NaturalLanguageInference,
+    NaturalLanguageInferenceModel,
     get_available_nli_models,
 )
 from knowledge_verificator.qg.qg_model_factory import (
+    QuestionGenerationModel,
     create_model,
     get_available_qg_models,
 )
@@ -215,3 +217,57 @@ def get_nli_model() -> dict:
         'available_models': get_available_nli_models(),
     }
     return format_response(data=data)
+
+
+@ENDPOINTS.post('/models/qg/{model_name}')
+def set_qg_model(model_name: str, response: Response) -> dict:
+    """
+    Endpoint to set the Question Generation model.
+
+    Args:
+        model_name (str): Name of the desired QG model.
+        response (Response): Instance of response, provided automatically.
+
+    Returns:
+        dict: If failed, only `message` key is available with the explanation
+            of the reasons of the failure. If successful, under `data` key
+            there is `model_name` key with the name of the new model.
+    """
+    try:
+        model = QuestionGenerationModel[model_name]
+        global QG_MODEL
+        QG_MODEL = create_model(model)
+        return format_response(data={'model_name': QG_MODEL.get_model()})
+    except KeyError:
+        response.status_code = 404
+        return format_response(
+            message='Cannot change the Question Generation model because name'
+            f' `{model_name}` has not been recognised.'
+        )
+
+
+@ENDPOINTS.post('/models/nli/{model_name}')
+def set_nli_model(model_name: str, response: Response) -> dict:
+    """
+    Endpoint to set the Natural Language Inference model.
+
+    Args:
+        model_name (str): Name of the desired NLI model.
+        response (Response): Instance of response, provided automatically.
+
+    Returns:
+        dict: If failed, only `message` key is available with the explanation
+        of the reasons of the failure. If successful, under `data` key
+        there is `model_name` key with the name of the new model.
+    """
+    try:
+        model = NaturalLanguageInferenceModel[model_name]
+        global NLI_MODEL
+        NLI_MODEL.set_model(model)
+        return format_response(data={'model_name': NLI_MODEL.get_model()})
+    except KeyError:
+        response.status_code = 404
+        return format_response(
+            message='Cannot change the Natural Language Inference model '
+            f'because name `{model_name}` has not been recognised.'
+        )

--- a/knowledge_verificator/backend.py
+++ b/knowledge_verificator/backend.py
@@ -6,11 +6,21 @@ from fastapi import FastAPI, Response
 
 from knowledge_verificator.materials import Material, MaterialDatabase
 from knowledge_verificator.io_handler import get_config
-from knowledge_verificator.qg.qg_model_factory import create_model
+from knowledge_verificator.nli import (
+    NaturalLanguageInference,
+    get_available_nli_models,
+)
+from knowledge_verificator.qg.qg_model_factory import (
+    create_model,
+    get_available_qg_models,
+)
 
 ENDPOINTS = FastAPI()
 MATERIAL_DB = MaterialDatabase(materials_dir=get_config().learning_materials)
 QG_MODEL = create_model(get_config().question_generation_model)
+NLI_MODEL = NaturalLanguageInference(
+    get_config().natural_language_inference_model
+)
 
 
 def format_response(data: Any = '', message: str = '') -> dict:
@@ -174,11 +184,34 @@ def update_material(material: Material, response: Response) -> dict:
 @ENDPOINTS.get('/models/qg')
 def get_qg_model() -> dict:
     """
-    Endpoint to provide name of currently chosen Question Generation model.
+    Endpoint to provide name of the currently chosen Question Generation model,
+    and other available models.
 
     Returns:
-        dict: Under `data` key, there is `model_name` key containing the name
-        of the current Question Generation model.
+        dict: Under `data` key, there is `loaded_model` key containing the name
+        of the current Question Generation model, and under `available_models`
+        a list of all the available QG models.
     """
-    data = {'model_name': QG_MODEL.get_model()}
+    data = {
+        'loaded_model': QG_MODEL.get_model(),
+        'available_models': get_available_qg_models(),
+    }
+    return format_response(data=data)
+
+
+@ENDPOINTS.get('/models/nli')
+def get_nli_model() -> dict:
+    """
+    Endpoint to provide name of the currently chosen Natural Language Inference model and,
+    other available models.
+
+    Returns:
+        dict: Under `data` key, there is `loaded_model` key containing the name
+        of the current Natural Language Inference model, and under `available_models`
+        the list of all the available NLI models.
+    """
+    data = {
+        'loaded_model': NLI_MODEL.get_model(),
+        'available_models': get_available_nli_models(),
+    }
     return format_response(data=data)

--- a/knowledge_verificator/backend.py
+++ b/knowledge_verificator/backend.py
@@ -235,7 +235,7 @@ def set_qg_model(model_name: str, response: Response) -> dict:
     """
     try:
         model = QuestionGenerationModel[model_name]
-        global QG_MODEL
+        global QG_MODEL  # type: ignore[global-statement]
         QG_MODEL = create_model(model)
         return format_response(data={'model_name': QG_MODEL.get_model()})
     except KeyError:
@@ -262,7 +262,6 @@ def set_nli_model(model_name: str, response: Response) -> dict:
     """
     try:
         model = NaturalLanguageInferenceModel[model_name]
-        global NLI_MODEL
         NLI_MODEL.set_model(model)
         return format_response(data={'model_name': NLI_MODEL.get_model()})
     except KeyError:

--- a/knowledge_verificator/backend.py
+++ b/knowledge_verificator/backend.py
@@ -235,7 +235,8 @@ def set_qg_model(model_name: str, response: Response) -> dict:
     """
     try:
         model = QuestionGenerationModel[model_name]
-        global QG_MODEL  # type: ignore[global-statement]
+        global QG_MODEL  # pylint: disable=global-statement
+
         QG_MODEL = create_model(model)
         return format_response(data={'model_name': QG_MODEL.get_model()})
     except KeyError:

--- a/knowledge_verificator/backend.py
+++ b/knowledge_verificator/backend.py
@@ -6,9 +6,11 @@ from fastapi import FastAPI, Response
 
 from knowledge_verificator.materials import Material, MaterialDatabase
 from knowledge_verificator.io_handler import get_config
+from knowledge_verificator.qg.qg_model_factory import create_model
 
 ENDPOINTS = FastAPI()
 MATERIAL_DB = MaterialDatabase(materials_dir=get_config().learning_materials)
+QG_MODEL = create_model(get_config().question_generation_model)
 
 
 def format_response(data: Any = '', message: str = '') -> dict:
@@ -167,3 +169,16 @@ def update_material(material: Material, response: Response) -> dict:
         message=f'Updated the material with id = {material.id}.',
         data=MATERIAL_DB[material.id],
     )
+
+
+@ENDPOINTS.get('/models/qg')
+def get_qg_model() -> dict:
+    """
+    Endpoint to provide name of currently chosen Question Generation model.
+
+    Returns:
+        dict: Under `data` key, there is `model_name` key containing the name
+        of the current Question Generation model.
+    """
+    data = {'model_name': QG_MODEL.get_model()}
+    return format_response(data=data)

--- a/knowledge_verificator/command_line.py
+++ b/knowledge_verificator/command_line.py
@@ -6,7 +6,7 @@ from knowledge_verificator.io_handler import logger, console, get_config
 from knowledge_verificator.answer_chooser import AnswerChooser
 from knowledge_verificator.materials import MaterialDatabase
 from knowledge_verificator.nli import NaturalLanguageInference, Relation
-from knowledge_verificator.qg import QuestionGeneration
+from knowledge_verificator.qg.qg_model_factory import create_model
 from knowledge_verificator.utils.menu import choose_from_menu
 
 
@@ -42,10 +42,10 @@ def run_cli_mode():
     Raises:
         ValueError:
     """
-    qg_module = QuestionGeneration()
+    config = get_config()
+    qg_module = create_model(config.question_generation_model)
     ac_module = AnswerChooser()
     nli_module = NaturalLanguageInference()
-    config = get_config()
 
     while True:
         options = ['knowledge database', 'my own paragraph']

--- a/knowledge_verificator/command_line.py
+++ b/knowledge_verificator/command_line.py
@@ -45,7 +45,9 @@ def run_cli_mode():
     config = get_config()
     qg_module = create_model(config.question_generation_model)
     ac_module = AnswerChooser()
-    nli_module = NaturalLanguageInference()
+    nli_module = NaturalLanguageInference(
+        model=config.natural_language_inference_model
+    )
 
     while True:
         options = ['knowledge database', 'my own paragraph']

--- a/knowledge_verificator/main.py
+++ b/knowledge_verificator/main.py
@@ -25,7 +25,7 @@ if __name__ == '__main__':
 
             uvicorn.run(
                 'knowledge_verificator.backend:ENDPOINTS',
-                host='127.0.0.1',
-                port=8000,
+                host=config.server,
+                port=config.port,
                 reload=(not config.production_mode),
             )

--- a/knowledge_verificator/qg/__init__.py
+++ b/knowledge_verificator/qg/__init__.py
@@ -1,0 +1,1 @@
+"""Module with all implementation of Question Generation models."""

--- a/knowledge_verificator/qg/base.py
+++ b/knowledge_verificator/qg/base.py
@@ -3,7 +3,7 @@
 from abc import ABC, abstractmethod
 
 
-class QuestionGeneration(ABC):  # pylint: disable=too-few-public-methods
+class QuestionGeneration(ABC):
     """Class for generating question based on supplied context."""
 
     @abstractmethod

--- a/knowledge_verificator/qg/base.py
+++ b/knowledge_verificator/qg/base.py
@@ -1,0 +1,29 @@
+"""Module with an interface of question generation module."""
+
+from abc import ABC, abstractmethod
+
+
+class QuestionGeneration(ABC):  # pylint: disable=too-few-public-methods
+    """Class for generating question based on supplied context."""
+
+    @abstractmethod
+    def generate(self, answer: str, context: str) -> dict[str, str]:
+        """
+        Generate a question based on a supplied context and answer.
+
+        Args:
+            answer (str): Correct answer to a question to be generated.
+            context (str): Contextual information, useful for question generation.
+
+        Returns:
+            dict[str, str]: Dictionary with a generated question, and a provided answer and context.
+        """
+
+    @abstractmethod
+    def get_model(self) -> str:
+        """
+        Get a nicely-formatted name of the used question generation model.
+
+        Returns:
+            str: Name of the model.
+        """

--- a/knowledge_verificator/qg/qg_model_factory.py
+++ b/knowledge_verificator/qg/qg_model_factory.py
@@ -1,0 +1,28 @@
+"""Module with factory of Question Generation (QG) models."""
+
+from knowledge_verificator.qg.base import QuestionGeneration
+from knowledge_verificator.qg.t5 import T5FineTuned
+
+
+def create_model(model_name: str) -> QuestionGeneration:
+    """
+    Instantiate a Question Generation model by the provided name.
+
+    Args:
+        model_name (str): Name of the model.
+
+    Raises:
+        ValueError: Raised if the provided name does not match to any model.
+
+    Returns:
+        QuestionGeneration: Instance of Question Generation model.
+    """
+
+    match model_name:
+        case 'T5 (fine-tuned)':
+            return T5FineTuned()
+
+        case _:
+            raise ValueError(
+                f'Unknown Question Generation model name: {model_name}.'
+            )

--- a/knowledge_verificator/qg/qg_model_factory.py
+++ b/knowledge_verificator/qg/qg_model_factory.py
@@ -1,28 +1,34 @@
 """Module with factory of Question Generation (QG) models."""
 
+from enum import Enum
 from knowledge_verificator.qg.base import QuestionGeneration
 from knowledge_verificator.qg.t5 import T5FineTuned
 
 
-def create_model(model_name: str) -> QuestionGeneration:
+class QuestionGenerationModel(Enum):
+    """Enumeration with the available Question Generation models."""
+
+    T5 = T5FineTuned
+
+
+def create_model(model: QuestionGenerationModel) -> QuestionGeneration:
     """
-    Instantiate a Question Generation model by the provided name.
+    Instantiate a Question Generation module with the desired model.
 
     Args:
-        model_name (str): Name of the model.
-
-    Raises:
-        ValueError: Raised if the provided name does not match to any model.
+        model (QuestionGenerationModel): Chosen QG model.
 
     Returns:
         QuestionGeneration: Instance of Question Generation model.
     """
+    return model.value()
 
-    match model_name:
-        case 'T5 (fine-tuned)':
-            return T5FineTuned()
 
-        case _:
-            raise ValueError(
-                f'Unknown Question Generation model name: {model_name}.'
-            )
+def get_available_qg_models() -> list[str]:
+    """
+    Get a list of available Question Generation models.
+
+    Returns:
+        list[str]: _description_
+    """
+    return [model.name for model in QuestionGenerationModel]

--- a/knowledge_verificator/qg/t5.py
+++ b/knowledge_verificator/qg/t5.py
@@ -1,12 +1,12 @@
 """Module with implementation of T5 Fine-Tuned Question Generation model."""
 
-from knowledge_verificator.qg.base import QuestionGeneration  # type: ignore[import-untyped]
 import warnings
 import torch
-from transformers import T5Tokenizer, T5ForConditionalGeneration
+from transformers import T5Tokenizer, T5ForConditionalGeneration  # type: ignore[import-untyped]
+from knowledge_verificator.qg.base import QuestionGeneration
 
 
-class T5FineTuned(QuestionGeneration):  # pylint: disable=too-few-public-methods
+class T5FineTuned(QuestionGeneration):
     """Class for generating question based on supplied context."""
 
     def __init__(self) -> None:
@@ -72,4 +72,4 @@ class T5FineTuned(QuestionGeneration):  # pylint: disable=too-few-public-methods
         Returns:
             str: Name of the model.
         """
-        return 'T5 (fine-tuned)'
+        return 'T5'

--- a/knowledge_verificator/qg/t5.py
+++ b/knowledge_verificator/qg/t5.py
@@ -1,28 +1,29 @@
-"""Module with question generation model."""
+"""Module with implementation of T5 Fine-Tuned Question Generation model."""
 
+from knowledge_verificator.qg.base import QuestionGeneration  # type: ignore[import-untyped]
 import warnings
 import torch
-from transformers import T5Tokenizer, T5ForConditionalGeneration  # type: ignore[import-untyped]
+from transformers import T5Tokenizer, T5ForConditionalGeneration
 
 
-class QuestionGeneration:  # pylint: disable=too-few-public-methods
+class T5FineTuned(QuestionGeneration):  # pylint: disable=too-few-public-methods
     """Class for generating question based on supplied context."""
 
     def __init__(self) -> None:
         warnings.filterwarnings('ignore', category=FutureWarning)
-        self.trained_model_path = (
+        self._trained_model_path = (
             'ZhangCheng/T5-Base-Fine-Tuned-for-Question-Generation'
         )
-        self.trained_tokenizer_path = (
+        self._trained_tokenizer_path = (
             'ZhangCheng/T5-Base-Fine-Tuned-for-Question-Generation'
         )
 
         self.model = T5ForConditionalGeneration.from_pretrained(
-            self.trained_model_path,
+            self._trained_model_path,
         )
 
         self.tokenizer = T5Tokenizer.from_pretrained(
-            self.trained_tokenizer_path,
+            self._trained_tokenizer_path,
             clean_up_tokenization_spaces=True,
             legacy=True,
         )
@@ -63,3 +64,12 @@ class QuestionGeneration:  # pylint: disable=too-few-public-methods
             clean_up_tokenization_spaces=True,
         )
         return {'question': question, 'answer': answer, 'context': context}
+
+    def get_model(self) -> str:
+        """
+        Get a nicely-formatted name of the used question generation model.
+
+        Returns:
+            str: Name of the model.
+        """
+        return 'T5 (fine-tuned)'

--- a/knowledge_verificator/utils/configuration_parser.py
+++ b/knowledge_verificator/utils/configuration_parser.py
@@ -9,7 +9,9 @@ from typing import Any
 import yaml  # type: ignore[import-untyped]
 
 from knowledge_verificator.nli import NaturalLanguageInferenceModel
-from knowledge_verificator.qg.qg_model_factory import QuestionGenerationModel  # type: ignore[import-untyped]
+from knowledge_verificator.qg.qg_model_factory import (
+    QuestionGenerationModel,  # type: ignore[import-untyped]
+)
 
 
 class OperatingMode(Enum):
@@ -71,6 +73,7 @@ class Configuration:
         for attribute, value in kwargs.items():
             self.__setattr__(attribute, value)
 
+        logger = logging.Logger('Configuration parser', level=logging.DEBUG)
         # Convert to a proper datatypes.
         try:
             self.natural_language_inference_model = (
@@ -79,9 +82,8 @@ class Configuration:
                 ]
             )
 
-        # FIXME: Use custom logger (but do not import from io_handler as it causes circular import error.)
         except KeyError as e:
-            logging.critical(
+            logger.critical(
                 'Unknown configuration option for `natural_language_inference`: %s.',
                 e,
             )
@@ -92,7 +94,7 @@ class Configuration:
                 kwargs['question_generation_model'].upper()
             ]
         except KeyError as e:
-            logging.critical(
+            logger.critical(
                 'Unknown configuration option for `question_generation_model`: %s.',
                 e,
             )

--- a/knowledge_verificator/utils/configuration_parser.py
+++ b/knowledge_verificator/utils/configuration_parser.py
@@ -53,6 +53,10 @@ class Configuration:
     experiment_implementation: Path
     experiment_results: Path
     production_mode: bool
+    server: str
+    port: int
+    question_generation_model: str
+    natural_language_inference_model: str
 
     def __init__(
         self,

--- a/poetry.lock
+++ b/poetry.lock
@@ -1242,6 +1242,26 @@ dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
+name = "protobuf"
+version = "5.28.2"
+description = ""
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "protobuf-5.28.2-cp310-abi3-win32.whl", hash = "sha256:eeea10f3dc0ac7e6b4933d32db20662902b4ab81bf28df12218aa389e9c2102d"},
+    {file = "protobuf-5.28.2-cp310-abi3-win_amd64.whl", hash = "sha256:2c69461a7fcc8e24be697624c09a839976d82ae75062b11a0972e41fd2cd9132"},
+    {file = "protobuf-5.28.2-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:a8b9403fc70764b08d2f593ce44f1d2920c5077bf7d311fefec999f8c40f78b7"},
+    {file = "protobuf-5.28.2-cp38-abi3-manylinux2014_aarch64.whl", hash = "sha256:35cfcb15f213449af7ff6198d6eb5f739c37d7e4f1c09b5d0641babf2cc0c68f"},
+    {file = "protobuf-5.28.2-cp38-abi3-manylinux2014_x86_64.whl", hash = "sha256:5e8a95246d581eef20471b5d5ba010d55f66740942b95ba9b872d918c459452f"},
+    {file = "protobuf-5.28.2-cp38-cp38-win32.whl", hash = "sha256:87317e9bcda04a32f2ee82089a204d3a2f0d3c8aeed16568c7daf4756e4f1fe0"},
+    {file = "protobuf-5.28.2-cp38-cp38-win_amd64.whl", hash = "sha256:c0ea0123dac3399a2eeb1a1443d82b7afc9ff40241433296769f7da42d142ec3"},
+    {file = "protobuf-5.28.2-cp39-cp39-win32.whl", hash = "sha256:ca53faf29896c526863366a52a8f4d88e69cd04ec9571ed6082fa117fac3ab36"},
+    {file = "protobuf-5.28.2-cp39-cp39-win_amd64.whl", hash = "sha256:8ddc60bf374785fb7cb12510b267f59067fa10087325b8e1855b898a0d81d276"},
+    {file = "protobuf-5.28.2-py3-none-any.whl", hash = "sha256:52235802093bd8a2811abbe8bf0ab9c5f54cca0a751fdd3f6ac2a21438bffece"},
+    {file = "protobuf-5.28.2.tar.gz", hash = "sha256:59379674ff119717404f7454647913787034f03fe7049cbef1d74a97bb4593f0"},
+]
+
+[[package]]
 name = "py"
 version = "1.11.0"
 description = "library with cross-python path, ini-parsing, io, code, log facilities"
@@ -2746,4 +2766,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "641d77274fd2ddc9a0668e8de2ed66bdf095a9b5cad190059b295c05a2cb7958"
+content-hash = "c1def47d6db056b2d35c7175268d8c65f452a584bb30d7403fa5f51d456c44b0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,10 @@ mypy = "^1.11.2"
 ruff = "^0.6.5"
 
 [tool.ruff]
+include = ["*.py"]
 line-length = 80
 indent-width = 4
+
 
 target-version = "py312"
 
@@ -51,6 +53,8 @@ unfixable = ["B"]
 
 [tool.ruff.format]
 quote-style = "single"
+indent-style = "space"
+docstring-code-format = true
 
 [tool.mypy]
 # Exclude module causing Internal error in mypy.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ sentence-transformers = "^3.1.1"
 fastapi = {extras = ["standard"], version = "^0.115.2"}
 pyyaml = "^6.0.2"
 requests = "^2.32.3"
+protobuf = "^5.28.2"
 
 [tool.poetry.group.test]
 

--- a/tests/model/qg_experiment.py
+++ b/tests/model/qg_experiment.py
@@ -5,7 +5,7 @@ import yaml  # type: ignore[import-untyped]
 import numpy as np
 from sentence_transformers import SentenceTransformer
 
-from knowledge_verificator.qg import QuestionGeneration
+from knowledge_verificator.qg.t5 import T5FineTuned
 from tests.model.runner import Metric, Result
 
 
@@ -23,9 +23,9 @@ def measure_qg_performance_with_cosine_similarity() -> Result:
     ) as fd:
         test_data = yaml.safe_load(fd)
 
-    qg = QuestionGeneration()
+    qg = T5FineTuned()
     metric = Metric.COSINE_SIMILARITY
-    model_name = qg.trained_model_path.split('/')[1]
+    model_name = qg._trained_model_path.split('/')[1]
     data_points: np.ndarray = np.zeros(shape=(len(test_data), 1))
 
     for i, test_item in enumerate(test_data):

--- a/tests/model/qg_experiment.py
+++ b/tests/model/qg_experiment.py
@@ -25,7 +25,7 @@ def measure_qg_performance_with_cosine_similarity() -> Result:
 
     qg = T5FineTuned()
     metric = Metric.COSINE_SIMILARITY
-    model_name = qg._trained_model_path.split('/')[1]
+    model_name = qg.get_model()
     data_points: np.ndarray = np.zeros(shape=(len(test_data), 1))
 
     for i, test_item in enumerate(test_data):

--- a/tests/software/test_config.yaml
+++ b/tests/software/test_config.yaml
@@ -4,3 +4,7 @@ production_mode: true
 learning_materials: ./test_database
 experiment_implementation: ./tests/model
 experiment_results: ./tests/model/results
+port: 8000
+server: 127.0.0.1
+question_generation_model: T5 (fine-tuned)
+natural_language_inference_model: roberta

--- a/tests/software/test_config.yaml
+++ b/tests/software/test_config.yaml
@@ -6,5 +6,5 @@ experiment_implementation: ./tests/model
 experiment_results: ./tests/model/results
 port: 8000
 server: 127.0.0.1
-question_generation_model: T5 (fine-tuned)
+question_generation_model: t5
 natural_language_inference_model: roberta

--- a/tests/software/test_materials_database.py
+++ b/tests/software/test_materials_database.py
@@ -51,7 +51,7 @@ def server(mock_args, database_directory):
         kwargs={'host': SERVER, 'port': PORT, 'reload': False},
     )
     process.start()
-    wait_for_server_startup(timeout=10)
+    wait_for_server_startup(timeout=15)
 
     yield
 

--- a/tests/software/test_materials_database.py
+++ b/tests/software/test_materials_database.py
@@ -57,6 +57,7 @@ def server(mock_args, database_directory):
 
     process.terminate()
     process.join(10)
+    process.kill()
 
 
 def wait_for_server_startup(timeout: int = 10) -> None:

--- a/tests/software/test_materials_database.py
+++ b/tests/software/test_materials_database.py
@@ -112,7 +112,7 @@ def send_request(
     return (content, response.status_code)
 
 
-def test_getting_empty_database(material):
+def test_getting_empty_database():
     """Test if the empty database returns no materials when requested."""
     response, _ = send_request(
         endpoint='materials',

--- a/tests/software/test_nli.py
+++ b/tests/software/test_nli.py
@@ -2,13 +2,19 @@
 
 import pytest
 
-from knowledge_verificator.nli import Relation, NaturalLanguageInference
+from knowledge_verificator.nli import (
+    NaturalLanguageInferenceModel,
+    Relation,
+    NaturalLanguageInference,
+)
 
 
 @pytest.fixture
 def nli() -> NaturalLanguageInference:
-    """Provide NaturalLanuageInference class for tests."""
-    model = NaturalLanguageInference()
+    """Provide Natural Language Inference module for tests."""
+    model = NaturalLanguageInference(
+        model=NaturalLanguageInferenceModel.ROBERTA
+    )
     return model
 
 

--- a/tests/software/test_qg.py
+++ b/tests/software/test_qg.py
@@ -3,17 +3,17 @@
 import pytest
 
 from transformers import set_seed  # type: ignore[import-untyped]
-from knowledge_verificator.qg import QuestionGeneration
+from knowledge_verificator.qg.t5 import T5FineTuned
 
 
 @pytest.fixture
 def qg():
     """
     Provide non-deterministically initialized instance of
-    the `QuestionGeneration` class.
+    the Question Generation model.
     """
     set_seed(0)
-    question_generation = QuestionGeneration()
+    question_generation = T5FineTuned()
     return question_generation
 
 


### PR DESCRIPTION
The goal is to implement switching Question Generation and Natural Inference models via API endpoints. Default models should be set in `config.yaml`.

Suggested layout of API endpoints:
- GET, `/models/qg/` - get the name of the current QG model and all the available models,
- POST `/model/qg/`- set the name of the QG model,
- GET, `/models/nli/` - get the name of the current NLI model and all the available models,
- POST `/model/nli/`- set the name of the NLI model.

After merging solves #16